### PR TITLE
Fixes formField.vue

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -1,12 +1,13 @@
 <template>
     <default-field :field="field">
         <template slot="field">
-            <div class="flex flex-wrap items-stretch w-full mb-4 relative">
+            <div class="flex flex-wrap items-stretch w-full relative h-full">
                 <div class="flex -mr-px">
-                    <span class="flex items-center leading-normal bg-grey-lighter rounded rounded-r-none border border-r-0 border-grey-light px-3 whitespace-no-wrap text-grey-dark text-sm">{{ field.currency }}</span>
+                    <span class="flex items-center bg-30 rounded-r-none px-3 whitespace-no-wrap text-sm form-control form-input-bordered">{{ field.currency }}</span>
                 </div>
                 <input :id="field.name" type="text"
-                    class="flex-shrink flex-grow flex-auto leading-normal w-px flex-1 border h-10 border-grey-light rounded rounded-l-none px-3 relative focus:border-blue focus:shadow"
+                    class="flex-1 relative focus:border-blue focus:shadow form-control form-input form-input-bordered"
+                    style="border-top-left-radius: 0;border-bottom-left-radius: 0;"
                     :class="errorClasses"
                     :placeholder="field.name"
                     v-model="value"


### PR DESCRIPTION
Nova had excluded or overwritten more styles than anticipated, this fixed the design.

Takes the design from:
![0](https://user-images.githubusercontent.com/2234034/45364890-9067ff00-b5db-11e8-84c6-914f89984677.png)


to:
![1](https://user-images.githubusercontent.com/2234034/45364901-95c54980-b5db-11e8-8356-2d36f984b219.png)
