### PR TITLE
Allow Field attributes personalization.

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -5,11 +5,10 @@
                 <div class="flex -mr-px">
                     <span class="flex items-center bg-30 rounded-r-none px-3 whitespace-no-wrap text-sm form-control form-input-bordered">{{ field.currency }}</span>
                 </div>
-                <input :id="field.name" type="text"
+                <input :id="field.attribute" type="number"
                        class="flex-1 relative focus:border-blue focus:shadow form-control form-input form-input-bordered"
                        style="border-top-left-radius: 0;border-bottom-left-radius: 0;"
-                       :class="errorClasses"
-                       :placeholder="field.name"
+                       v-bind="extraAttributes"
                        v-model="value"
                 />
             </div>
@@ -27,7 +26,33 @@
         mixins: [FormField, HandlesValidationErrors],
 
         props: ['resourceName', 'resourceId', 'field'],
+        
+        computed: {
+            defaultAttributes() {
+                return {
+                    type: this.field.type || 'number',
+                    min: this.field.min,
+                    max: this.field.max,
+                    step: this.field.step,
+                    pattern: this.field.pattern,
+                    placeholder: this.field.placeholder || this.field.name,
+                    class: this.errorClasses,
+                }
+            },
 
+            extraAttributes() {
+                const attrs = this.field.extraAttributes
+
+                return {
+                    // Leave the default attributes even though we can now specify
+                    // whatever attributes we like because the old number field still
+                    // uses the old field attributes
+                    ...this.defaultAttributes,
+                    ...attrs,
+                }
+            },
+        },
+    
         methods: {
             /*
              * Set the initial, internal value for the field.

--- a/src/Money.php
+++ b/src/Money.php
@@ -29,6 +29,8 @@ class Money extends Number
             'subUnits' => $this->subunits($currency),
         ]);
 
+        $this->step(1 / $this->minorUnit($currency));
+
         $this
             ->resolveUsing(function ($value) use ($currency) {
                 return $this->inMinorUnits ? $value / $this->minorUnit($currency) : $value;


### PR DESCRIPTION
Should fix id attribute (used name instead of attribute), and allow personalizing field type, min, max, pattern, and all attributes you want.

Set default step to 1/minorUnit (if €, subUnits = 2, so minorUnit = 100, so step = 0.01)

Fix #14 

Warning: Compilation is to do.

Thanks.
