### PR TITLE
maximumFractionDigits relative to subUnits

### DIFF
--- a/resources/js/components/mixin.js
+++ b/resources/js/components/mixin.js
@@ -1,12 +1,12 @@
 export default {
     computed: {
         formattedValue() {
-            if (!this.field.value) return '';
+            if (this.field.value === undefined) return '';
             return this.field.value.toLocaleString(this.field.locale, {
                 style: 'currency',
                 currency: this.field.currency,
                 minimumFractionDigits: 2,
-                maximumFractionDigits: 2
+                maximumFractionDigits: this.field.subUnits
             });
         },
     }


### PR DESCRIPTION
Fixes #13 
maximumFractionDigits must be relative to subUnits.
I use money field to show Bitcoin and need to show more extended fraction like 0.000002 